### PR TITLE
tx: ensure rpc txs are correctly decoded for v=0 (#2705)

### DIFF
--- a/packages/statemanager/test/ethersStateManager.spec.ts
+++ b/packages/statemanager/test/ethersStateManager.spec.ts
@@ -226,7 +226,7 @@ tape('runTx test: replay mainnet transactions', async (t) => {
     const blockTag = 15496077n
     common.setHardforkByBlockNumber(blockTag)
     const txData = require('./testdata/providerData/transactions/0xed1960aa7d0d7b567c946d94331dddb37a1c67f51f30bf51f256ea40db88cfb0.json')
-    const tx = await TransactionFactory.fromRPCTx(txData, { common })
+    const tx = await TransactionFactory.fromRPC(txData, { common })
     const state = new EthersStateManager({
       provider,
       // Set the state manager to look at the state of the chain before the block has been executed

--- a/packages/tx/src/fromRpc.ts
+++ b/packages/tx/src/fromRpc.ts
@@ -28,7 +28,7 @@ export const normalizeTxParams = (_txParams: any): TxData => {
   txParams.r = txParams.r === '0x0' ? '0x' : txParams.r
   txParams.s = txParams.s === '0x0' ? '0x' : txParams.s
 
-  if (txParams.v !== '0x') {
+  if (txParams.v !== '0x' || txParams.r !== '0x' || txParams.s !== '0x') {
     txParams.v = toType(txParams.v, TypeOutput.BigInt)
   }
 

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -113,7 +113,7 @@ export class TransactionFactory {
     if (txData === null) {
       throw new Error('No data returned from provider')
     }
-    return TransactionFactory.fromRPCTx(txData, txOptions)
+    return TransactionFactory.fromRPC(txData, txOptions)
   }
 
   /**
@@ -123,7 +123,7 @@ export class TransactionFactory {
    * @param txOptions The transaction options
    * @returns
    */
-  public static async fromRPCTx(
+  public static async fromRPC(
     txData: TxData | AccessListEIP2930TxData | FeeMarketEIP1559TxData | BlobEIP4844TxData,
     txOptions: TxOptions = {}
   ) {

--- a/packages/tx/test/fromRpc.spec.ts
+++ b/packages/tx/test/fromRpc.spec.ts
@@ -6,6 +6,7 @@ import { TransactionFactory } from '../src'
 import { normalizeTxParams } from '../src/fromRpc'
 
 const optimismTx = require('./json/optimismTx.json')
+const v0Tx = require('./json/v0tx.json')
 
 const txTypes = [0, 1, 2]
 
@@ -74,13 +75,32 @@ tape('[normalizeTxParams]', (t) => {
   t.end()
 })
 
-tape('fromRPCTx: ensure v/r/s values of 0x0 are interpreted as undefined', async function (st) {
+tape(
+  'fromRPC: ensure v/r/s values of 0x0 are interpreted as undefined for Optimism system txs',
+  async function (st) {
+    for (const txType of txTypes) {
+      optimismTx.type = txType
+      const tx = await TransactionFactory.fromRPC(optimismTx)
+      st.ok(tx.v === undefined)
+      st.ok(tx.s === undefined)
+      st.ok(tx.r === undefined)
+    }
+    st.end()
+  }
+)
+
+// This test ensures that "normal" txs of non-legacy type are correctly decoded if the
+// `v` value is 0. This is the case in ~50% of the EIP2930 and EIP1559 txs
+// The `v` value is either 0 or 1 there.
+tape('fromRPC: ensure `v="0x0"` is correctly decoded for signed txs', async function (st) {
   for (const txType of txTypes) {
-    optimismTx.type = txType
-    const tx = await TransactionFactory.fromRPCTx(optimismTx)
-    st.ok(tx.v === undefined)
-    st.ok(tx.s === undefined)
-    st.ok(tx.r === undefined)
+    if (txType === 0) {
+      // legacy tx cannot have v=0
+      continue
+    }
+    v0Tx.type = txType
+    const tx = await TransactionFactory.fromRPC(v0Tx)
+    st.ok(tx.isSigned())
   }
   st.end()
 })

--- a/packages/tx/test/json/v0tx.json
+++ b/packages/tx/test/json/v0tx.json
@@ -1,0 +1,21 @@
+{
+  "blockHash": "0x3606c8bf399c20a09058551eea1f1b4f7df9973f6fc390afbaef80df16bb8a81",
+  "blockNumber": "0x12306",
+  "from": "0x9791ded6e5d3d5dafca71bb7bb2a14187d17e32e",
+  "gas": "0x186a0",
+  "gasPrice": "0x3b9b1368",
+  "maxFeePerGas": "0x3b9b1368",
+  "maxPriorityFeePerGas": "0x3b9b1360",
+  "hash": "0xd2cdf63bb15eb4bbc655e4cca198c92305f2c6d057ac993ef6f7bacf1c518b2f",
+  "input": "0x2c377f89e8b86b5ab3f0a42d7de72abf0e36236b0f8b3808413eed75adbd18f704382c60d6527f2e2ae515f197908fe9a752498882a14fbef2c8c1b7cc1067635c466a85958e6360f6527fcba24c994bc47b3b2acda7f774254170e125720a726e10ceda22855f856696b9610116527fce789b987b5942fa40de0809968c8bc7",
+  "nonce": "0xaa595",
+  "to": "0x2665c0a20514cdc3fd5e18173d7b6d7ba125e5c0",
+  "transactionIndex": "0x2",
+  "value": "0x0",
+  "type": "0x2",
+  "accessList": [],
+  "chainId": "0x10f2c",
+  "v": "0x0",
+  "r": "0x2e6e55a09bbc97e0bb6f80d54c5e63a4604dcaa5bffadb991669792553e075b4",
+  "s": "0x601a59743e1704bced353df169c1bd1af188ddd6738a7032b4a6f7f9c52c3143"
+}


### PR DESCRIPTION
* tx: ensure rpc txs are correctly decoded for v=0

* stateManager: fix test / rename fromRPCTx in tx to fromRPC in tests